### PR TITLE
Global error ghost

### DIFF
--- a/src/lock/global_error.jsx
+++ b/src/lock/global_error.jsx
@@ -33,8 +33,8 @@ export default class GlobalError extends React.Component {
       node.style.height = height;
       node.style.paddingTop = paddingTop;
       node.style.paddingBottom = paddingBottom;
+      callback();
     }, 17);
-    callback();
   }
 
   // componentDidEnter() {
@@ -48,7 +48,13 @@ export default class GlobalError extends React.Component {
     node.style.height = "0px";
     node.style.paddingTop = "0px";
     node.style.paddingBottom = "0px";
-    setTimeout(callback, 300);
+    setTimeout(function() {
+      node.style.removeProperty("transition");
+      node.style.removeProperty("height");
+      node.style.removeProperty("padding-top");
+      node.style.removeProperty("padding-bottom");
+      callback();
+    }, 250);
   }
 
   // componentDidLeave() {

--- a/src/passwordless/actions.js
+++ b/src/passwordless/actions.js
@@ -70,7 +70,7 @@ export function requestPasswordlessEmail(id) {
 
     webApi.startPasswordless(id, options, error => {
       if (error) {
-        requestPasswordlessEmailError(id, error);
+        setTimeout(() => requestPasswordlessEmailError(id, error), 250);
       } else {
         requestPasswordlessEmailSuccess(id);
       }
@@ -115,7 +115,7 @@ export function sendSMS(id) {
     const options = {phoneNumber: c.fullPhoneNumber(lock)};
     webApi.startPasswordless(id, options, error => {
       if (error) {
-        sendSMSError(id, error);
+        setTimeout(() => sendSMSError(id, error), 250);
       } else {
         sendSMSSuccess(id);
       }
@@ -203,7 +203,13 @@ export function signIn(id) {
     webApi.signIn(
       id,
       Map(options).merge(l.login.authParams(lock)).toJS(),
-      (error, ...args) => error ? signInError(id, error) : signInSuccess(id, ...args)
+      (error, ...args) => {
+        if (error) {
+          setTimeout(() => signInError(id, error), 250);
+        } else {
+          signInSuccess(id, ...args);
+        }
+      }
     );
   }
 }


### PR DESCRIPTION
Fixes #38 by cleaning inline styles from the current error message before showing the next.

It also adds a little delay before showing the error message from an unsuccessful response. This allows to perform a smoother transition between two errors.