### PR TITLE
Upgrade to React 0.14.

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,9 +79,11 @@
   "dependencies": {
     "auth0-js": "^6.7.2",
     "blueimp-md5": "^1.1.0",
+    "fbjs": "^0.3.1",
     "immutable": "^3.7.3",
     "jsonp": "^0.2.0",
-    "react": "^0.13.3",
+    "react": "^0.14.0-rc1",
+    "react-dom": "^0.14.0-rc1",
     "trim": "0.0.1"
   }
 }

--- a/src/cred/email_input.jsx
+++ b/src/cred/email_input.jsx
@@ -10,8 +10,7 @@ export default class EmailInput extends React.Component {
   }
 
   componentDidMount() {
-    const node = React.findDOMNode(this.refs.input);
-    const email = node.value;
+    const email = this.refs.input.value;
     if (email && this.props.gravatar) {
       requestGravatar(email);
     }

--- a/src/cred/location_select.jsx
+++ b/src/cred/location_select.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import Icon from '../icon/icon';
 import * as cc from './country_codes';
 import * as su from '../utils/string_utils';
@@ -21,7 +22,7 @@ export default class LocationSelect extends React.Component {
   componentDidMount() {
     if (!isSmallScreen()) {
       setTimeout(() => {
-        const node = React.findDOMNode(this.refs.input);
+        const node = this.refs.input;
         node.focus();
         if (node.setSelectionRange) {
           const length = node.value.length;
@@ -137,12 +138,11 @@ class LocationList extends React.Component {
     // expressed more clearly.
     const { highlighted } = this.refs;
     if (highlighted) {
-      const scrollableNode = React.findDOMNode(this);
-      const highlightedNode = React.findDOMNode(highlighted);
-      const relativeOffsetTop = highlightedNode.offsetTop - scrollableNode.scrollTop;
+      const scrollableNode = ReactDOM.findDOMNode(this);
+      const relativeOffsetTop = highlighted.offsetTop - scrollableNode.scrollTop;
       let scrollTopDelta = 0;
-      if (relativeOffsetTop + highlightedNode.offsetHeight > scrollableNode.clientHeight) {
-        scrollTopDelta = relativeOffsetTop + highlightedNode.offsetHeight - scrollableNode.clientHeight;
+      if (relativeOffsetTop + highlighted.offsetHeight > scrollableNode.clientHeight) {
+        scrollTopDelta = relativeOffsetTop + highlighted.offsetHeight - scrollableNode.clientHeight;
       } else if (relativeOffsetTop < 0) {
         scrollTopDelta = relativeOffsetTop;
       }

--- a/src/cred/phone_number_input.jsx
+++ b/src/cred/phone_number_input.jsx
@@ -27,7 +27,7 @@ export default class PhoneNumberInput extends React.Component {
   }
 
   focus() {
-    React.findDOMNode(this.refs.input).focus();
+    this.refs.input.focus();
     this.handleFocus();
   }
 

--- a/src/cred/vcode_input.jsx
+++ b/src/cred/vcode_input.jsx
@@ -14,7 +14,7 @@ export default class VcodeInput extends React.Component {
       // TODO: We can't set the focus immediately because we have to wait for
       // the input to be visible. Use a more robust solution (Placeholder should
       // notify it children when they are being shown).
-      setTimeout(() => React.findDOMNode(this.refs.input).focus(), 1200);
+      setTimeout(() => this.refs.input.focus(), 1200);
     }
   }
 

--- a/src/lock/cred_pane.jsx
+++ b/src/lock/cred_pane.jsx
@@ -74,8 +74,8 @@ export default class CredPane extends React.Component {
   }
 
   componentWillSlideIn(slide) {
-    const node = React.findDOMNode(this.refs.content);
-    this.originalHeight = parseInt(window.getComputedStyle(node, null).height, 10);
+    const height = window.getComputedStyle(this.refs.content, null).height;
+    this.originalHeight = parseInt(height, 10);
     this.setState({height: slide.height, show: false});
   }
 
@@ -85,8 +85,7 @@ export default class CredPane extends React.Component {
   }
 
   componentWillSlideOut(callback) {
-    const node = React.findDOMNode(this.refs.content);
-    const size = window.getComputedStyle(node, null).height;
+    const size = window.getComputedStyle(this.refs.content, null).height;
     callback({height: parseInt(size, 10), reverse: this.reverse});
   }
 

--- a/src/lock/global_error.jsx
+++ b/src/lock/global_error.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 
 export default class GlobalError extends React.Component {
   render() {
@@ -20,7 +21,7 @@ export default class GlobalError extends React.Component {
 
   componentWillEnter(callback) {
     // console.log("componentWillEnter");
-    const node = React.findDOMNode(this);
+    const node = ReactDOM.findDOMNode(this);
     var computedStyle = window.getComputedStyle(node, null);
     var height = computedStyle.height;
     var paddingTop = computedStyle.paddingTop;
@@ -43,7 +44,7 @@ export default class GlobalError extends React.Component {
 
   componentWillLeave(callback) {
     // console.log("componentWillLeave");
-    const node = React.findDOMNode(this);
+    const node = ReactDOM.findDOMNode(this);
     node.style.transition = "all 0.2s";
     node.style.height = "0px";
     node.style.paddingTop = "0px";

--- a/src/lock/renderer.js
+++ b/src/lock/renderer.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import CSSCore from 'react/lib/CSSCore';
+import ReactDOM from 'react-dom';
+import CSSCore from 'fbjs/lib/CSSCore';
 import ContainerManager from './container_manager';
 import Lock from './lock';
 import * as l from './index';
@@ -21,7 +22,7 @@ export default class Renderer {
         lock = lock.set("gravatar", gravatar && g.loaded(gravatar) ? gravatar : null);
         const container = this.containerManager.ensure(l.ui.containerID(lock), l.ui.appendContainer(lock));
         const renderFn = fns.get(l.mode(lock));
-        React.render(renderFn(lock), container);
+        ReactDOM.render(renderFn(lock), container);
       } else {
         let container;
         try {

--- a/src/lock/submit_button.jsx
+++ b/src/lock/submit_button.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import SubmitIcon from './submit_icon';
 
 export default class SubmitButton extends React.Component {
@@ -16,7 +17,7 @@ export default class SubmitButton extends React.Component {
   }
 
   focus() {
-    React.findDOMNode(this).focus();
+    ReactDOM.findDOMNode(this).focus();
   }
 }
 

--- a/src/multisize-slide/multisize_slide.js
+++ b/src/multisize-slide/multisize_slide.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import CSSCore from 'react/lib/CSSCore';
+import ReactDOM from 'react-dom';
+import CSSCore from 'fbjs/lib/CSSCore';
 
 export default class Slider extends React.Component {
   constructor(props) {
@@ -31,7 +32,7 @@ export default class Slider extends React.Component {
       const prevComponent = this.refs[prev.key];
 
       const transition = (component, className, delay) => {
-        const node = React.findDOMNode(component);
+        const node = ReactDOM.findDOMNode(component);
         const activeClassName = `${className}-active`;
 
         CSSCore.addClass(node, className);


### PR DESCRIPTION
This required adding react-dom and fbjs as dependencies.

* react-dom includes the `ReactDOM.render` and `ReactDOM.findDOMNode`
* fbjs includes `CSSCore`

From there it was a mostly mechanical conversion.

Note this has *not* been extensively tested. I basically just tried the
demo.

Fixes #63 