### PR TITLE
Icon preload

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Initializes a new instance of `Auth0LockPasswordless` configured with your appli
 
 - **clientID {String}**: Your application _clientID_ in Auth0.
 - **domain {String}**: Your Auth0 _domain_. Usually _your-account.auth0.com_.
+- **options {Object}**: Allows to customize the dialog's appearance and behavior. See [below](#customization) for the details.
 
 You can find this information at your [application settings](https://manage.auth0.com/#/applications).
 
@@ -283,14 +284,14 @@ lock.logout({ref: window.location.href});
 
 ### Customization
 
-The appearance of the widget and the mechanics of authentication can be customized with an `options` object which has one or more of the following properties. Each method that opens the dialog can take an `options` object as its first argument.
+The appearance of the widget and the mechanics of authentication can be customized with an `options` object which has one or more of the following properties. The `Auth0LockPasswordless` constructor and each method that opens the dialog can take an `options` object. Options passed to an opening method take precedence over options passed to the constructor.
 
 #### UI options
 
 - **autoclose {Boolean}**: Determines whether or not the Lock will be closed automatically after a successful sign in. If the Lock is not `closable` it won't be closed even if this option is set to `true`. Defaults to `false`.
 - **container {String}**: The `id` of the html element where the Lock will be rendered. This makes the Lock appear inline instead of in a modal window.
 - **dict {Object}**: Allows to customize every piece of text displayed in the Lock. Defaults to `{}`. See below [Dict Specification](#dict-specification) for the details.
-- **icon {String}**: Url for an image that will be placed in the Lock's header. Defaults to Auth0's logo.
+- **icon {String}**: Url for an image that will be placed in the Lock's header. Defaults to Auth0's logo. If you are going to use a custom icon is recommended that you specify this option when constructing a new `Auth0LockPasswordless` instance because that give us the chance to preload the image and provide a better user experience.
 - **closable {Boolean}**: Determines whether or not the Lock can be closed. When a `container` option is provided its value is always `false`, otherwise it defaults to `true`.
 - **defaultLocation {String}**: [ISO country code](http://www.iso.org/iso/country_codes) of the country that will be selected by default when entering a phone number. Defaults to `"US"`.
 - **focusInput {Boolean}**: Determines whether or not the first input on the screen, that is the email or phone number input, should have focus when the Lock is displayed. Defaults to `false` when a `container` option is provided or the Lock is being render on a mobile device. Otherwise it defaults to `true`.

--- a/css/index.css
+++ b/css/index.css
@@ -231,7 +231,7 @@
   position: relative;
 }
 .auth0-lock.auth0-lock .auth0-lock-header-logo {
-  width: 50px;
+  height: 55px;
   display: inline-block;
   margin: 8px 0;
   vertical-align: middle;

--- a/css/index.styl
+++ b/css/index.styl
@@ -245,7 +245,7 @@ breakpoint(point, value = 0)
     position relative
 
   .auth0-lock-header-logo
-    width 50px
+    height 55px
     display inline-block
     margin 8px 0
     vertical-align middle

--- a/src/atom/index.js
+++ b/src/atom/index.js
@@ -1,8 +1,3 @@
-// TODO: Hack to preload the default icon. We need to preload also custom icons
-// and prevent showing the lock until they are loaded.
-const img = document.createElement("img");
-img.src = "//cdn.auth0.com/styleguide/1.0.0/img/badge.png";
-
 class Atom {
   constructor(state) {
     this.state = state;

--- a/src/gravatar/web_api.js
+++ b/src/gravatar/web_api.js
@@ -1,6 +1,7 @@
 import { md5 } from 'blueimp-md5';
 import { validateEmail } from '../cred/index';
 import jsonp from '../utils/jsonp_utils';
+import * as preload from '../preload/index';
 
 export function profile(email, success, error) {
   if (validateEmail(email)) {
@@ -22,11 +23,9 @@ export function profile(email, success, error) {
 export function img(email, success, error) {
   if (validateEmail(email)) {
     const url = `https://secure.gravatar.com/avatar/${md5(email)}?d=404`;
-    const img = document.createElement("img");
-    img.addEventListener("load", () => { success(email, img); });
-    img.addEventListener("error", () => { error(email) });
-    img.src = url;
-    return img;
+    preload.img(url, function(err, img) {
+      err ? error(email) : success(email, img);
+    });
   } else {
     error(email);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ import version from 'package.version';
 import Auth0 from 'auth0-js';
 
 export default class Auth0LockPasswordless {
-  constructor(clientID, domain) {
+  constructor(clientID, domain, defaultOptions = {}) {
     if (typeof clientID != "string") {
       throw new Error("A `clientID` string must be provided as first argument.");
     }
@@ -26,7 +26,7 @@ export default class Auth0LockPasswordless {
     }
 
     this.id = idu.incremental();
-    setupLock(this.id, clientID, domain);
+    setupLock(this.id, clientID, domain, defaultOptions);
   }
 
   close() {

--- a/src/lock/actions.js
+++ b/src/lock/actions.js
@@ -4,8 +4,13 @@ import { getEntity, read, removeEntity, swap, setEntity, updateEntity } from '..
 import * as l from './index';
 import * as cs from '../cred/storage';
 
-export function setupLock(id, clientID, domain) {
-  const lock = l.setup({id: id, clientID: clientID, domain: domain});
+export function setupLock(id, clientID, domain, defaultOptions) {
+  const lock = l.setup({
+    id: id,
+    clientID: clientID,
+    domain: domain,
+    defaultOptions: defaultOptions
+  });
   swap(setEntity, "lock", id, lock);
 
   WebAPI.setupClient(id, clientID, domain);

--- a/src/lock/actions.js
+++ b/src/lock/actions.js
@@ -3,8 +3,12 @@ import WebAPI from './web_api';
 import { getEntity, read, removeEntity, swap, setEntity, updateEntity } from '../store/index';
 import * as l from './index';
 import * as cs from '../cred/storage';
+import * as preload from '../preload/index';
 
 export function setupLock(id, clientID, domain, defaultOptions) {
+  const icon = defaultOptions && defaultOptions.icon;
+  preload.img((icon && typeof icon === "string") ? icon : l.DEFAULT_ICON_URL);
+
   const lock = l.setup({
     id: id,
     clientID: clientID,

--- a/src/lock/index.js
+++ b/src/lock/index.js
@@ -5,12 +5,13 @@ import * as d from '../dict/index';
 import t from '../dict/t';
 
 export function setup(attrs) {
-  const { clientID, domain, id } = attrs;
+  const { clientID, defaultOptions, domain, id } = attrs;
 
   return Immutable.fromJS({
     clientID: clientID,
     domain: domain,
-    id: id
+    id: id,
+    defaultOptions: defaultOptions
   });
 }
 
@@ -174,6 +175,7 @@ export function render(m, modeName, options) {
     modeOptions: modeOptions
   }));
 
+  options = m.get("defaultOptions").mergeDeep(Immutable.fromJS(options)).toJS();
   m = setUIOptions(m, options);
   m = setLoginOptions(m, options);
 

--- a/src/lock/index.js
+++ b/src/lock/index.js
@@ -4,6 +4,8 @@ import { iconUrl } from '../icon/index';
 import * as d from '../dict/index';
 import t from '../dict/t';
 
+export const DEFAULT_ICON_URL = "//cdn.auth0.com/styleguide/1.0.0/img/badge.png";
+
 export function setup(attrs) {
   const { clientID, defaultOptions, domain, id } = attrs;
 
@@ -80,7 +82,7 @@ function extractUIOptions(id, options) {
     containerID: options.container || `auth0-lock-container-${id}`,
     appendContainer: !options.container,
     autoclose: undefined === options.autoclose ? false : closable && options.autoclose,
-    icon: options.icon || "//cdn.auth0.com/styleguide/1.0.0/img/badge.png",
+    icon: options.icon || DEFAULT_ICON_URL,
     closable: closable,
     dict: d.build(dictName, typeof options.dict === "object" ? options.dict : {}),
     focusInput: undefined === options.focusInput ? !(options.container || isSmallScreen()) : !!options.focusInput,

--- a/src/lock/index.js
+++ b/src/lock/index.js
@@ -177,7 +177,7 @@ export function render(m, modeName, options) {
     modeOptions: modeOptions
   }));
 
-  options = m.get("defaultOptions").mergeDeep(Immutable.fromJS(options)).toJS();
+  options = m.get("defaultOptions").merge(Immutable.fromJS(options)).toJS();
   m = setUIOptions(m, options);
   m = setLoginOptions(m, options);
 

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -1,0 +1,7 @@
+export function img(src, cb) {
+  const img = document.createElement("img");
+  img.addEventListener("load", () => { cb(null, img); });
+  img.addEventListener("error", (event) => { cb(event) });
+  img.src = src;
+  return img;
+}

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -1,4 +1,4 @@
-export function img(src, cb) {
+export function img(src, cb = () => {}) {
   const img = document.createElement("img");
   img.addEventListener("load", () => { cb(null, img); });
   img.addEventListener("error", (event) => { cb(event) });

--- a/test/gravatar/web_api.test.js
+++ b/test/gravatar/web_api.test.js
@@ -11,6 +11,7 @@ let fail, success;
 describe("fetching image", function() {
   let img;
 
+  // TODO: stub preload.img and add tests for preload.
   function getCallback(name) {
     for (var i = 0; i < img.addEventListener.callCount; i++) {
       if (img.addEventListener.getCall(i).args[0] == name) {
@@ -20,7 +21,8 @@ describe("fetching image", function() {
   }
 
   function invokeCallback(name) {
-    return getCallback(name).args[1].call();
+    const args = [name === "error" ? {} : undefined];
+    return getCallback(name).args[1].apply(undefined, args);
   }
 
   beforeEach(function() {

--- a/test/lock/index.test.js
+++ b/test/lock/index.test.js
@@ -8,6 +8,7 @@ let lock;
 const clientID = "someClientID";
 const lockID = "someLockID";
 const domain = "tenant.auth0.com";
+const defaultOptions = {};
 
 describe("initializing a lock", function() {
   beforeEach(function() {
@@ -15,6 +16,7 @@ describe("initializing a lock", function() {
       clientID: clientID,
       domain: domain,
       id: lockID,
+      defaultOptions: defaultOptions,
       nonexistent: "nonexistent"
     });
   });
@@ -29,6 +31,10 @@ describe("initializing a lock", function() {
 
   it("sets the domain", function() {
     expect(l.domain(lock)).to.be(domain);
+  });
+
+  it("sets the default options domain", function() {
+    expect(lock.get("defaultOptions").toJS()).to.eql(defaultOptions);
   });
 
   it("doesn't set unknown attributes", function() {
@@ -62,7 +68,12 @@ describe("rendering a lock", function() {
   const modeOptions = {someModeOption: "someModeOption"};
 
   beforeEach(function() {
-    lock = l.setup({clientID: clientID, domain: domain, id: lockID});
+    lock = l.setup({
+      clientID: clientID,
+      domain: domain,
+      id: lockID,
+      defaultOptions: defaultOptions
+    });
     renderedLock = l.render(lock, mode, {modeOptions: modeOptions});
   });
 
@@ -218,7 +229,12 @@ describe("rerendering a lock", function() {
   // const modeOptions = {someModeOption: "someModeOption"};
 
   beforeEach(function() {
-    lock = l.setup({clientID: clientID, domain: domain, id: lockID});
+    lock = l.setup({
+      clientID: clientID,
+      domain: domain,
+      id: lockID,
+      defaultOptions: defaultOptions
+    });
     renderedLock = l.render(lock, mode, {});
     reRenderedLock = l.render(renderedLock, mode, {});
   });
@@ -340,7 +356,12 @@ describe("trying to render a lock that is being shown", function() {
   const mode = "someMode";
 
   beforeEach(function() {
-    lock = l.setup({clientID: clientID, domain: domain, id: lockID});
+    lock = l.setup({
+      clientID: clientID,
+      domain: domain,
+      id: lockID,
+      defaultOptions: defaultOptions
+    });
     openedLock = l.setShow(l.render(lock, mode, {}), true);
     reRenderedLock = l.render(openedLock, mode, {gravatar: false});
   });
@@ -355,7 +376,12 @@ describe("submitting", function() {
   const globalError = "Something went wrong.";
 
   beforeEach(function() {
-    lock = l.setup({clientID: clientID, domain: domain, id: lockID});
+    lock = l.setup({
+      clientID: clientID,
+      domain: domain,
+      id: lockID,
+      defaultOptions: defaultOptions
+    });
     lockWithGlobalError = l.setGlobalError(lock, globalError);
     submittingLock = l.setSubmitting(lockWithGlobalError, true);
   });
@@ -423,7 +449,12 @@ describe("accessing Gravatar info", function() {
   let renderedLock;
 
   beforeEach(function() {
-    lock = l.setup({clientID: clientID, domain: domain, id: lockID});
+    lock = l.setup({
+      clientID: clientID,
+      domain: domain,
+      id: lockID,
+      defaultOptions: defaultOptions
+    });
   });
 
   describe("when it has to be displayed", function() {


### PR DESCRIPTION
This PR changes the `Auth0LockPasswordless` constructor to allow an options object as the last argument which is merged with the options object passed to `magiclink`, `emailcode` or `sms`. The sole purpose of this change is to allow us to preload the icon image.

**Before**
```js
var lock = new Auth0LockPasswordless(clientID, domain);
```

**After**
```js
var options = {icon: "http://domain.com/my-icon.png"};
var lock = new Auth0LockPasswordless(clientID, domain, options);
```

There is also a styling fix that will ensure the Lock's title is always in the same position. It no longer depends on the icon dimension and on whether is loaded or not.



