### PR TITLE
Playground fixes

### DIFF
--- a/support/playground/index.js
+++ b/support/playground/index.js
@@ -25,6 +25,8 @@ function bindEvents () {
 
   $('#show-lock').on('click', showLockHandler);
 
+  // Render a new Lock in the #container after it has been closed by clicking
+  // its close button.
   $('body').on('click', '.auth0-lock-close-button', function(ev) {
     ev.preventDefault();
 

--- a/support/playground/index.js
+++ b/support/playground/index.js
@@ -28,10 +28,6 @@ function bindEvents () {
   $('body').on('click', '.auth0-lock-close-button', function(ev) {
     ev.preventDefault();
 
-    if($(this).parents('.output-box-result').length) {
-      return;
-    }
-
     showLockHandler();
   });
 

--- a/support/playground/index.js
+++ b/support/playground/index.js
@@ -35,12 +35,12 @@ function bindEvents () {
     showLockHandler();
   });
 
+  // Render a new Lock in the #container after it has been closed with ESC.
+  // Sometimes, pressing ESC won't close the lock. For instance, when selecting
+  // a location, ESC will close the selector. So, we use the close button as a
+  // flag.
   $('body').on('keydown', function(ev) {
-    if($('.auth0-lock-opened').length && ev.keyCode) {
-      if($('.auth0-lock-opened').parents('.output-box-result').length) {
-        return;
-      }
-
+    if(ev.keyCode === 27 && $('.auth0-lock-opened .auth0-lock-close-button').length) {
       showLockHandler();
     }
   });


### PR DESCRIPTION
- After clicking the "Open Me!" button, the lock was being closed when any key was pressed.
- Clean event handler for close button click. The close button is never displayed when the Lock is rendered in a container, so there's no need to check that.
- Add comments for event handlers that render the Lock in the container after it has been closed.