### PR TITLE
Ensure Facebook page looks fine in the popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## unreleased
+
+### Fixed
+
+- Ensure Facebook page looks fine in the popup by passing the `display: "popup"` option.
+
 ## [2.0.0] - 2015-12-03
 
 ### Changed

--- a/src/cred/social/social_button.jsx
+++ b/src/cred/social/social_button.jsx
@@ -29,7 +29,7 @@ export default class SocialButton extends React.Component {
 
   handleClick() {
     const { lock, connection } = this.props;
-    signIn(l.id(lock), connection.name);
+    signIn(l.id(lock), connection);
   }
 }
 

--- a/src/social/actions.js
+++ b/src/social/actions.js
@@ -9,7 +9,7 @@ export function signIn(id, connection) {
   const lock = read(getEntity, "lock", id);
 
   const options = {
-    connection: connection,
+    connection: connection.name,
     popup: l.ui.popup(lock),
     popupOptions: l.ui.popupOptions(lock),
     redirect: !l.ui.popup(lock),
@@ -18,6 +18,11 @@ export function signIn(id, connection) {
     forceJSONP: l.login.forceJSONP(lock)
     // sso: false
   };
+
+  if (l.ui.popup(lock) && connection.strategy === "facebook") {
+    options.display = "popup";
+  }
+
   WebAPI.signIn(id, options,  (error, ...args) => {
     if (error) {
       setTimeout(() => signInError(id, error), 250);


### PR DESCRIPTION
We need to pass the `display: "popup"` option.