### PR TITLE
Playground fixes

### DIFF
--- a/support/playground/index.html
+++ b/support/playground/index.html
@@ -131,7 +131,7 @@
                     <div class="form-group">
                       <label class="col-xs-12 col-sm-4 col-md-3 control-label col-left">Connections</label>
                       <div class="col-xs-12 col-sm-8 col-md-9 col-right">
-                        <input type="text" name="connections" class="form-control" placeholder="['facebook', 'twitter']">
+                        <input type="text" name="connections" class="form-control" placeholder='["facebook", "twitter"]' value='["facebook", "twitter"]'>
                         <span class="help-block">List of social providers that will be available to perform the authentication. Most of the time you will specify a provider with the connection name, e.g. 'facebook'. When the connection's 'name' and 'strategy' don't match, you'll need to provide an object with those properties, e.g. '{name: "my-connection", strategy: "facebook"}'.  This option doesn't have a default value and must be specified when opening the Lock with a method that provides social authentication.</span>
                       </div>
                     </div>

--- a/support/playground/index.html
+++ b/support/playground/index.html
@@ -226,7 +226,7 @@
                         </label>
                       </div>
                       <div class="col-xs-12 col-sm-6 col-md-6 form-group-checkbox">
-                        <input type="checkbox" name="socialBigButtons">
+                        <input type="checkbox" name="socialBigButtons" checked>
                         <label class="control-label">Social Big Buttons
                           <span class="help tip-right" rel="tooltip" data-original-title="Determines the size of the buttons for the social providers specified in the 'connections' option. It defaults to 'true' when the 'connections' option contains at most tree providers, otherwise it defaults to 'false'.">
                             <i class="fa fa-question-circle">&nbsp;</i>


### PR DESCRIPTION
- Provide `connections` by default (because in social modes the Lock won't open without it)
- Check `socialBigButtons` by default