### PR TITLE
Webpack fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "grunt-exec": "^0.4.6",
     "grunt-http": "^1.6.0",
     "mochify": "^2.12.0",
-    "react-addons-test-utils": "0.14.6",
+    "react-addons-test-utils": "^0.14.0",
     "sinon": "^1.15.4",
     "unreleased": "^0.1.0",
     "zuul": "^3.2.0",
@@ -67,10 +67,10 @@
     "fbjs": "^0.3.1",
     "immutable": "^3.7.3",
     "jsonp": "^0.2.0",
-    "react": "0.14.6",
-    "react-addons-css-transition-group": "0.14.6",
-    "react-addons-transition-group": "0.14.6",
-    "react-dom": "0.14.6",
+    "react": "^0.14.0",
+    "react-addons-css-transition-group": "^0.14.0",
+    "react-addons-transition-group": "^0.14.0",
+    "react-dom": "^0.14.0",
     "reqwest": "^1.1.4",
     "trim": "0.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "grunt-exec": "^0.4.6",
     "grunt-http": "^1.6.0",
     "mochify": "^2.12.0",
-    "react-addons-test-utils": "0.14.5",
+    "react-addons-test-utils": "0.14.6",
     "sinon": "^1.15.4",
     "unreleased": "^0.1.0",
     "zuul": "^3.2.0",
@@ -67,10 +67,10 @@
     "fbjs": "^0.3.1",
     "immutable": "^3.7.3",
     "jsonp": "^0.2.0",
-    "react": "0.14.5",
-    "react-addons-css-transition-group": "0.14.5",
-    "react-addons-transition-group": "0.14.5",
-    "react-dom": "0.14.5",
+    "react": "0.14.6",
+    "react-addons-css-transition-group": "0.14.6",
+    "react-addons-transition-group": "0.14.6",
+    "react-dom": "0.14.6",
     "reqwest": "^1.1.4",
     "trim": "0.0.1"
   }

--- a/src/gravatar/web_api.js
+++ b/src/gravatar/web_api.js
@@ -1,7 +1,9 @@
-import { md5 } from 'blueimp-md5';
+import blueimp from 'blueimp-md5';
 import { validateEmail } from '../cred/index';
 import jsonp from '../utils/jsonp_utils';
 import * as preload from '../preload/index';
+
+const md5 = blueimp.md5 || blueimp;
 
 export function profile(email, success, error) {
   if (validateEmail(email)) {


### PR DESCRIPTION
- Relax react dependency, to avoid the problem of two react versions running alongside.
- Change the way the blueimp library is required to avoid issues with webpack.