### PR TITLE
Don't crash if String.prototype is changed, closes #104

### DIFF
--- a/src/lock/chrome.jsx
+++ b/src/lock/chrome.jsx
@@ -33,7 +33,7 @@ export default class Chrome extends React.Component {
 
     const gravatar = l.gravatar(lock);
     const icon = l.ui.icon(lock);
-    const globalError = l.globalError(lock);
+    const globalError = l.globalError(lock) || null;
     const disableSubmit = l.submitting(lock);
 
     let backgroundUrl, name;


### PR DESCRIPTION
The globalError was always provided as a child of ReactTransitonGroup even when it was the empty string. ReactTransitionGroup performs a for..in loop over its children, which iterates over the enumerable
properties of the object, including the ones that inherits such as the properties added to String.prototype.

To avoid the issue, use null instead of the global error message when it is empty.