### PR TITLE
Make big social button text customizable

### DIFF
--- a/src/cred/or/ask_social_network_or_email.jsx
+++ b/src/cred/or/ask_social_network_or_email.jsx
@@ -28,8 +28,8 @@ export default class AskSocialNetworkOrEmail extends Screen {
       <div>
         <SocialButtonsPane
           lock={lock}
+          t={this.t.bind(this)}
           smallButtonsHeader={this.t(lock, ["smallSocialButtonsHeader"], {__textOnly: true})}
-          bigButtonsPrefix={this.t(lock, ["bigSocialButtonsPrefix"], {__textOnly: true})}
         />
         <PaneSeparator>{this.t(lock, ["separatorText"])}</PaneSeparator>
         <EmailPane

--- a/src/cred/or/ask_social_network_or_email.jsx
+++ b/src/cred/or/ask_social_network_or_email.jsx
@@ -29,6 +29,7 @@ export default class AskSocialNetworkOrEmail extends Screen {
         <SocialButtonsPane
           lock={lock}
           smallButtonsHeader={this.t(lock, ["smallSocialButtonsHeader"], {__textOnly: true})}
+          bigButtonsPrefix={this.t(lock, ["bigSocialButtonsPrefix"], {__textOnly: true})}
         />
         <PaneSeparator>{this.t(lock, ["separatorText"])}</PaneSeparator>
         <EmailPane

--- a/src/cred/or/ask_social_network_or_phone_number.jsx
+++ b/src/cred/or/ask_social_network_or_phone_number.jsx
@@ -23,8 +23,8 @@ export default class AskSocialNetworkOrPhoneNumber extends Base {
       <div>
         <SocialButtonsPane
           lock={lock}
+          t={this.t.bind(this)}
           smallButtonsHeader={this.t(lock, ["smallSocialButtonsHeader"], {__textOnly: true})}
-          bigButtonsPrefix={this.t(lock, ["bigSocialButtonsPrefix"], {__textOnly: true})}
         />
         <PaneSeparator>{this.t(lock, ["separatorText"])}</PaneSeparator>
         <PhoneNumberPane

--- a/src/cred/or/ask_social_network_or_phone_number.jsx
+++ b/src/cred/or/ask_social_network_or_phone_number.jsx
@@ -24,6 +24,7 @@ export default class AskSocialNetworkOrPhoneNumber extends Base {
         <SocialButtonsPane
           lock={lock}
           smallButtonsHeader={this.t(lock, ["smallSocialButtonsHeader"], {__textOnly: true})}
+          bigButtonsPrefix={this.t(lock, ["bigSocialButtonsPrefix"], {__textOnly: true})}
         />
         <PaneSeparator>{this.t(lock, ["separatorText"])}</PaneSeparator>
         <PhoneNumberPane

--- a/src/cred/social/ask_social_network.jsx
+++ b/src/cred/social/ask_social_network.jsx
@@ -20,6 +20,7 @@ export default class AskSocialNetwork extends Screen {
         lock={lock}
         showLoading={true}
         smallButtonsHeader={this.t(lock, ["smallSocialButtonsHeader"], {__textOnly: true})}
+        bigButtonsPrefix={this.t(lock, ["bigSocialButtonsPrefix"], {__textOnly: true})}
       />
     );
   }

--- a/src/cred/social/ask_social_network.jsx
+++ b/src/cred/social/ask_social_network.jsx
@@ -18,9 +18,9 @@ export default class AskSocialNetwork extends Screen {
     return(
       <SocialButtonsPane
         lock={lock}
+        t={this.t.bind(this)}
         showLoading={true}
         smallButtonsHeader={this.t(lock, ["smallSocialButtonsHeader"], {__textOnly: true})}
-        bigButtonsPrefix={this.t(lock, ["bigSocialButtonsPrefix"], {__textOnly: true})}
       />
     );
   }

--- a/src/cred/social/social_button.jsx
+++ b/src/cred/social/social_button.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import * as l from '../../lock/index';
 import { signIn } from '../../social/actions';
-import { displayName, useBigButtons } from '../../social/index';
+import { useBigButtons } from '../../social/index';
 
 export default class SocialButton extends React.Component {
   render() {
-    const { connection, disabled, lock, tabIndex, bigButtonsPrefix } = this.props;
+    const { connection, disabled, lock, tabIndex, socialButtonLabel } = this.props;
 
     let className = "auth0-lock-social-button";
     if (useBigButtons(lock)) className += " auth0-lock-social-big-button";
@@ -21,7 +21,7 @@ export default class SocialButton extends React.Component {
       >
         <div className="auth0-lock-social-button-icon" />
         <div className="auth0-lock-social-button-text">
-          {bigButtonsPrefix} {displayName(connection)}
+          {socialButtonLabel}
         </div>
       </button>
     );
@@ -38,7 +38,7 @@ SocialButton.propTypes = {
   connection: React.PropTypes.object.isRequired,
   disabled: React.PropTypes.bool.isRequired,
   tabIndex: React.PropTypes.number,
-  bigButtonsPrefix: React.PropTypes.string
+  socialButtonLabel: React.PropTypes.string
 };
 
 SocialButton.defaultProps = {

--- a/src/cred/social/social_button.jsx
+++ b/src/cred/social/social_button.jsx
@@ -5,7 +5,7 @@ import { displayName, useBigButtons } from '../../social/index';
 
 export default class SocialButton extends React.Component {
   render() {
-    const { connection, disabled, lock, tabIndex } = this.props;
+    const { connection, disabled, lock, tabIndex, bigButtonsPrefix } = this.props;
 
     let className = "auth0-lock-social-button";
     if (useBigButtons(lock)) className += " auth0-lock-social-big-button";
@@ -21,7 +21,7 @@ export default class SocialButton extends React.Component {
       >
         <div className="auth0-lock-social-button-icon" />
         <div className="auth0-lock-social-button-text">
-          Login with {displayName(connection)}
+          {bigButtonsPrefix} {displayName(connection)}
         </div>
       </button>
     );
@@ -37,7 +37,8 @@ SocialButton.propTypes = {
   lock: React.PropTypes.object.isRequired,
   connection: React.PropTypes.object.isRequired,
   disabled: React.PropTypes.bool.isRequired,
-  tabIndex: React.PropTypes.number
+  tabIndex: React.PropTypes.number,
+  bigButtonsPrefix: React.PropTypes.string
 };
 
 SocialButton.defaultProps = {

--- a/src/cred/social/social_buttons_pane.jsx
+++ b/src/cred/social/social_buttons_pane.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import SocialButton from './social_button';
 import * as l from '../../lock/index';
-import { useBigButtons } from '../../social/index';
+import { displayName, useBigButtons } from '../../social/index';
 export default class SocialButtonsPane extends React.Component {
 
   render() {
-    const { lock, showLoading, smallButtonsHeader, bigButtonsPrefix } = this.props;
+    const { lock, t, showLoading, smallButtonsHeader } = this.props;
 
     const header = !useBigButtons(lock)
       && smallButtonsHeader
@@ -14,7 +14,12 @@ export default class SocialButtonsPane extends React.Component {
          </p>;
 
     const buttons = l.ui.connections(lock).map(x => (
-      <SocialButton key={x.name} connection={x} lock={lock} bigButtonsPrefix={bigButtonsPrefix} />
+      <SocialButton
+        key={x.name}
+        connection={x}
+        lock={lock}
+        socialButtonLabel={t(lock, ["socialButtonLabel"], {provider: displayName(x), __textOnly: true})}
+      />
     ));
 
     const loading = showLoading
@@ -37,7 +42,7 @@ SocialButtonsPane.propTypes = {
   lock: React.PropTypes.object.isRequired,
   showLoading: React.PropTypes.bool.isRequired,
   smallButtonsHeader: React.PropTypes.string,
-  bigButtonsPrefix: React.PropTypes.string
+  socialButtonLabel: React.PropTypes.string
 };
 
 SocialButtonsPane.defaultProps = {

--- a/src/cred/social/social_buttons_pane.jsx
+++ b/src/cred/social/social_buttons_pane.jsx
@@ -5,7 +5,7 @@ import { useBigButtons } from '../../social/index';
 export default class SocialButtonsPane extends React.Component {
 
   render() {
-    const { lock, showLoading, smallButtonsHeader } = this.props;
+    const { lock, showLoading, smallButtonsHeader, bigButtonsPrefix } = this.props;
 
     const header = !useBigButtons(lock)
       && smallButtonsHeader
@@ -14,7 +14,7 @@ export default class SocialButtonsPane extends React.Component {
          </p>;
 
     const buttons = l.ui.connections(lock).map(x => (
-      <SocialButton key={x.name} connection={x} lock={lock} />
+      <SocialButton key={x.name} connection={x} lock={lock} bigButtonsPrefix={bigButtonsPrefix} />
     ));
 
     const loading = showLoading
@@ -36,7 +36,8 @@ export default class SocialButtonsPane extends React.Component {
 SocialButtonsPane.propTypes = {
   lock: React.PropTypes.object.isRequired,
   showLoading: React.PropTypes.bool.isRequired,
-  smallButtonsHeader: React.PropTypes.string
+  smallButtonsHeader: React.PropTypes.string,
+  bigButtonsPrefix: React.PropTypes.string
 };
 
 SocialButtonsPane.defaultProps = {

--- a/src/dict/dicts.js
+++ b/src/dict/dicts.js
@@ -79,7 +79,8 @@ export default {
     network: {
       footerText: "",
       headerText: "",
-      smallSocialButtonsHeader: "Login with"
+      smallSocialButtonsHeader: "Login with",
+      bigSocialButtonsPrefix: "Login with"
     },
     signedIn: {
       success: "Thanks for signing in."
@@ -98,7 +99,8 @@ export default {
       footerText: "",
       headerText: "",
       separatorText: "Otherwise, enter your email to sign in<br>or create an account",
-      smallSocialButtonsHeader: "Login with"
+      smallSocialButtonsHeader: "Login with",
+      bigSocialButtonsPrefix: "Login with"
     },
     signedIn: {
       success: "Thanks for signing in."
@@ -120,7 +122,8 @@ export default {
       footerText: "",
       headerText: "",
       separatorText: "Otherwise, enter your email to sign in<br>or create an account",
-      smallSocialButtonsHeader: "Login with"
+      smallSocialButtonsHeader: "Login with",
+      bigSocialButtonsPrefix: "Login with"
     },
     signedIn: {
       success: "Thanks for signing in."
@@ -146,7 +149,8 @@ export default {
       headerText: "",
       phoneNumberInputPlaceholder: "your phone number",
       separatorText: "Otherwise, enter your phone to sign in<br>or create an account",
-      smallSocialButtonsHeader: "Login with"
+      smallSocialButtonsHeader: "Login with",
+      bigSocialButtonsPrefix: "Login with"
     },
     title: "Auth0",
     welcome: "Welcome {name}!"

--- a/src/dict/dicts.js
+++ b/src/dict/dicts.js
@@ -80,7 +80,7 @@ export default {
       footerText: "",
       headerText: "",
       smallSocialButtonsHeader: "Login with",
-      bigSocialButtonsPrefix: "Login with"
+      socialButtonLabel: "Login with {provider}"
     },
     signedIn: {
       success: "Thanks for signing in."
@@ -100,7 +100,7 @@ export default {
       headerText: "",
       separatorText: "Otherwise, enter your email to sign in<br>or create an account",
       smallSocialButtonsHeader: "Login with",
-      bigSocialButtonsPrefix: "Login with"
+      socialButtonLabel: "Login with {provider}"
     },
     signedIn: {
       success: "Thanks for signing in."
@@ -123,7 +123,7 @@ export default {
       headerText: "",
       separatorText: "Otherwise, enter your email to sign in<br>or create an account",
       smallSocialButtonsHeader: "Login with",
-      bigSocialButtonsPrefix: "Login with"
+      socialButtonLabel: "Login with {provider}"
     },
     signedIn: {
       success: "Thanks for signing in."
@@ -150,7 +150,7 @@ export default {
       phoneNumberInputPlaceholder: "your phone number",
       separatorText: "Otherwise, enter your phone to sign in<br>or create an account",
       smallSocialButtonsHeader: "Login with",
-      bigSocialButtonsPrefix: "Login with"
+      socialButtonLabel: "Login with {provider}"
     },
     title: "Auth0",
     welcome: "Welcome {name}!"


### PR DESCRIPTION
Currently the header of small social buttons is customizable, but the prefix text of big social buttons text ('Login with') is not.
This PR makes it customizable via `dict`.
